### PR TITLE
Adding possibility to configure a path to a hook script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ IntelliJ plugin that allows you to run a hook prior commiting changes to any Ver
 
 Create a file named `pre-commit-hook.sh` or `pre-commit-hook.bat` for Windows, in your project root, exit with non-zero code to 'fail' the commit.
 
+Alternatively you can set custom path to your script:
+1. Open Settings -> Tools -> Pre Commit Hook
+2. Put a path to your script:
+   - relative path to your project root (e.g. tools/my_hook.sh)
+   - _or_ absolute path to your script (C://users/me/my_hook.bat)
+   - _or_ set to empty for default file (pre-commit-hook)
+
 ## Known Problems
 
 - MacOS : IntelliJ starts a new process with non-usual `PATH` environment variable. A bypass for now is to set the `PATH` within the script.

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>com.upsolver.PreCommitHook</id>
   <name>Pre Commit Hook Plugin</name>
-  <version>0.3.1</version>
+  <version>0.4.1</version>
   <vendor email="yahel.yechieli@gmail.com" url="https://github.com/yahely">Yahel Yechieli</vendor>
 
   <description><![CDATA[
@@ -14,6 +14,8 @@
       0.2 - Added Progress Indicator
       0.3 - Added Skip Buttons
       0.3.1 - Fixed null pointer when committing a deleted file
+      0.4.0 - Added possibility to configure a path to a script
+      0.4.1 - Fixed running non-windows script on windows (python, perl, etc.)
     ]]>
   </change-notes>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -23,6 +23,9 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <checkinHandlerFactory implementation="PreCommitCheckinHandlerFactory"  />
+    <projectConfigurable groupId="tools"
+                         displayName="Pre Commit Hook"
+                         instance="HookConfigurable" />
   </extensions>
 
 </idea-plugin>

--- a/src/HookConfigurable.java
+++ b/src/HookConfigurable.java
@@ -1,0 +1,141 @@
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.rt.execution.testFrameworks.ProcessBuilder;
+import com.intellij.uiDesigner.core.GridConstraints;
+import com.intellij.uiDesigner.core.GridLayoutManager;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class HookConfigurable implements Configurable {
+
+    private static final String PATH_KEY = "pre-commit-hook.path";
+    public static final String DEFAULT_FILE = ProcessBuilder.isWindows ? "pre-commit-hook.bat" : "pre-commit-hook.sh";
+
+    private JTextField pathTextField;
+    private String storedPath;
+
+    private final Project project;
+
+    public HookConfigurable(Project project) {
+        this.project = project;
+    }
+
+    @Nls
+    @Override
+    public String getDisplayName() {
+        return "Pre Commit Hook";
+    }
+
+    @Nullable
+    @Override
+    public String getHelpTopic() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        storedPath = getScriptPath(project);
+
+        pathTextField = new JTextField();
+
+        TextFieldWithBrowseButton fieldWithButton = new TextFieldWithBrowseButton(pathTextField);
+        fieldWithButton.addBrowseFolderListener("Select Hook Script", "", null,
+                FileChooserDescriptorFactory.createSingleFileDescriptor());
+
+        JPanel container = new JPanel(new GridLayoutManager(2, 2, new Insets(0, 0, 0, 0), 12, 12));
+
+        GridConstraints pathLabelConstraint = new GridConstraints();
+        pathLabelConstraint.setRow(0);
+        pathLabelConstraint.setColumn(0);
+        pathLabelConstraint.setFill(GridConstraints.FILL_HORIZONTAL);
+        pathLabelConstraint.setVSizePolicy(GridConstraints.SIZEPOLICY_CAN_SHRINK);
+        container.add(new JLabel("Script path"), pathLabelConstraint);
+
+        GridConstraints pathFieldConstraint = new GridConstraints();
+        pathFieldConstraint.setHSizePolicy(GridConstraints.SIZEPOLICY_WANT_GROW);
+        pathFieldConstraint.setFill(GridConstraints.FILL_HORIZONTAL);
+        pathFieldConstraint.setAnchor(GridConstraints.ANCHOR_WEST);
+        pathFieldConstraint.setRow(0);
+        pathFieldConstraint.setColumn(1);
+        pathFieldConstraint.setVSizePolicy(GridConstraints.SIZEPOLICY_CAN_SHRINK);
+        container.add(fieldWithButton, pathFieldConstraint);
+
+        JPanel spacer = new JPanel();
+        GridConstraints spacerConstraints = new GridConstraints();
+        spacerConstraints.setRow(1);
+        spacerConstraints.setFill(GridConstraints.FILL_BOTH);
+        container.add(spacer, spacerConstraints);
+
+        return container;
+    }
+
+    @Override
+    public boolean isModified() {
+        String fieldValue = getTrimmedFieldValue();
+
+        if (storedPath == null) {
+            return fieldValue != null;
+        }
+
+        return !storedPath.equals(fieldValue);
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        String filePath = getTrimmedFieldValue();
+
+        PropertiesComponent properties = PropertiesComponent.getInstance(project);
+        properties.setValue(PATH_KEY, filePath);
+
+        storedPath = filePath;
+    }
+
+    private String getTrimmedFieldValue() {
+        if (pathTextField == null) {
+            return null;
+        }
+
+        final String path = pathTextField.getText();
+        if (path == null) {
+            return null;
+        }
+
+        return path.trim();
+    }
+
+    @Override
+    public void reset() {
+        if (pathTextField != null) {
+            pathTextField.setText(storedPath);
+        }
+    }
+
+    @Override
+    public void disposeUIResources() {
+        storedPath = null;
+        pathTextField = null;
+    }
+
+    @NotNull
+    public static String getScriptPath(Project project) {
+        PropertiesComponent properties = PropertiesComponent.getInstance(project);
+        String path = properties.getValue(PATH_KEY);
+
+        if ((path == null) || (path.trim().isEmpty())) {
+            path = DEFAULT_FILE;
+        } else {
+            path = path.trim();
+        }
+
+        return path;
+    }
+}


### PR DESCRIPTION
Hi @yahely,
I added possibility to configure a path to hook script explicitly in Intellij Settings Window (under Tools section). 
By default the plugin still uses pre-commit-hook.bat/.sh scripts, if they exist.
But if a user specifies another script explicitly (for a project), then this script will be invoked